### PR TITLE
Dont run bundle exec rake when running tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ rvm:
   - 2.5.1
   - ruby-head  
 before_install: gem install bundler -v 1.16.2
+script: rake test


### PR DESCRIPTION
Travis CI does not appear to be working, see https://travis-ci.com/ruby/logger/jobs/164283690

The issue seems to be when running the test suite with `bundle exec rake test`. For now, we should run CI with just `rake test`.