### PR TITLE
Remove files that dont need to be included in gem releases

### DIFF
--- a/logger.gemspec
+++ b/logger.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ruby/logger"
   spec.license       = "BSD-2-Clause"
 
-  spec.files         = [".gitignore", ".travis.yml", "Gemfile", "LICENSE.txt", "README.md", "Rakefile", "bin/console", "bin/setup", "lib/logger.rb", "logger.gemspec"]
+  spec.files         = ["Gemfile", "LICENSE.txt", "README.md", "Rakefile", "lib/logger.rb", "logger.gemspec"]
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
The gemspec is specifying files like `.travis.yml` and `.gitignore` to be included in gem releases, which i don't think is required. 

This PR removes these files from the `files` entry in the gemspec