### PR TITLE
Add ruby 2.3.8, ruby 2.4.5, 2.6.0 and update 2.5 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.3.8
+  - 2.4.5
   - 2.5.1
   - ruby-head  
 before_install: gem install bundler -v 1.16.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 rvm:
   - 2.3.8
   - 2.4.5
-  - 2.5.1
+  - 2.5.3
+  - 2.6.0
   - ruby-head
 script: rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ rvm:
   - 2.3.8
   - 2.4.5
   - 2.5.1
-  - ruby-head  
+  - ruby-head
 before_install: gem install bundler -v 1.16.2
 script: rake test


### PR DESCRIPTION
I figured that it would be good practice to test all the supported versions of ruby in travis.