### PR TITLE
Dont lock bundler to a specific version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ language: ruby
 rvm:
   - 2.5.1
   - ruby-head  
-before_install: gem install bundler -v 1.16.2
 script: rake test

--- a/logger.gemspec
+++ b/logger.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
I can't think of a reason why Bundler needs to be locked to specifically `1.16.0`, we should be ok to use any version that the user has installed. (hopefully 🤞)