### PR TITLE
Say that logger requires ruby >= 2.3

### DIFF
--- a/logger.gemspec
+++ b/logger.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  
+  spec.required_ruby_version = ">= 2.3.0
 
   spec.add_development_dependency "bundler", ">= 0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/logger.gemspec
+++ b/logger.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   
-  spec.required_ruby_version = ">= 2.3.0
+  spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_development_dependency "bundler", ">= 0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Since it uses `&.`, it can't be used on older rubies