### PR TITLE
Add support for block with buffer.

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -467,7 +467,7 @@ class Logger
   # * Append open does not need to lock file.
   # * If the OS supports multi I/O, records possibly may be mixed.
   #
-  def add(severity, message = nil, progname = nil)
+  def add(severity, message = nil, progname = nil, &block)
     severity ||= UNKNOWN
     if @logdev.nil? or severity < @level
       return true
@@ -477,7 +477,13 @@ class Logger
     end
     if message.nil?
       if block_given?
-        message = yield
+        if block.arity > 0
+          buffer = StringIO.new
+          yield buffer
+          message = buffer.string
+        else
+          message = yield
+        end
       else
         message = progname
         progname = @progname

--- a/test/logger/test_buffer.rb
+++ b/test/logger/test_buffer.rb
@@ -1,0 +1,24 @@
+# coding: US-ASCII
+# frozen_string_literal: false
+require 'test/unit'
+require 'logger'
+
+class TestBuffer < Test::Unit::TestCase
+  def test_block_argument
+    r, w = IO.pipe
+    logger = Logger.new(w)
+    
+    logger.info do |buffer|
+      buffer.puts "Hello"
+      buffer.puts "World"
+    end
+    
+    IO.select([r], nil, nil, 0.1)
+    w.close
+    msg = r.read
+    r.close
+    
+    assert_include msg, "Hello"
+    assert_include msg, "World"
+  end
+end


### PR DESCRIPTION
I've been working on improving buffered log output for Ruby.

I've implemented my own logging library but I want to make it backwards compatible, so I want to make some new features in stdlib logger.

This feature makes it much simpler to do multi-line logging.

It can be augmented by using `StringIO` with custom `puts` which adds prefix. This can make logging output more readable, but I just wanted to start with basic change and see if we can improve it further with discussion.

This change is completely backwards compatible.