### PR TITLE
Add support for changing severity using bang methods.

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -322,21 +322,36 @@ class Logger
   # +DEBUG+ messages.
   def debug?; @level <= DEBUG; end
 
+  # Sets the severity to DEBUG.
+  def debug!; self.level = DEBUG; end
+
   # Returns +true+ iff the current severity level allows for the printing of
   # +INFO+ messages.
   def info?; @level <= INFO; end
+
+  # Sets the severity to INFO.
+  def info!; self.level = INFO; end
 
   # Returns +true+ iff the current severity level allows for the printing of
   # +WARN+ messages.
   def warn?; @level <= WARN; end
 
+  # Sets the severity to WARN.
+  def warn!; self.level = WARN; end
+
   # Returns +true+ iff the current severity level allows for the printing of
   # +ERROR+ messages.
   def error?; @level <= ERROR; end
 
+  # Sets the severity to ERROR.
+  def error!; self.level = ERROR; end
+
   # Returns +true+ iff the current severity level allows for the printing of
   # +FATAL+ messages.
   def fatal?; @level <= FATAL; end
+
+  # Sets the severity to FATAL.
+  def fatal!; self.level = FATAL; end
 
   #
   # :call-seq:

--- a/test/logger/test_severity.rb
+++ b/test/logger/test_severity.rb
@@ -13,4 +13,15 @@ class TestLoggerSeverity < Test::Unit::TestCase
     end
     assert_equal(levels.size, Logger::Severity.constants.size)
   end
+  
+  def test_level_assignment
+    logger = Logger.new(nil)
+    
+    Logger::Severity.constants.each do |level|
+      next if level == :UNKNOWN
+      
+      logger.send("#{level.downcase}!")
+      assert(logger.level) == Logger::Severity.const_get(level)
+    end
+  end
 end


### PR DESCRIPTION
This is a proposal to make it easier for 3rd party implementations to support same interface without depending on `Logger` constants.

Rather than writing `logger.level = Logger::DEBUG`, we can write `logger.debug!`. I believe this is better since it is aligned with the "Ask, don't tell" software design pattern.