### PR TITLE
Add support for block with buffer.

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 # logger.rb - simple logging utility
 # Copyright (C) 2000-2003, 2005, 2008, 2011  NAKAMURA, Hiroshi <nahi@ruby-lang.org>.
 #

--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -451,7 +451,7 @@ class Logger
   # * Append open does not need to lock file.
   # * If the OS supports multi I/O, records possibly may be mixed.
   #
-  def add(severity, message = nil, progname = nil)
+  def add(severity, message = nil, progname = nil, &block)
     severity ||= UNKNOWN
     if @logdev.nil? or severity < @level
       return true
@@ -461,7 +461,13 @@ class Logger
     end
     if message.nil?
       if block_given?
-        message = yield
+        if block.arity > 0
+          buffer = StringIO.new
+          yield buffer
+          message = buffer.string
+        else
+          message = yield
+        end
       else
         message = progname
         progname = @progname

--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # logger.rb - simple logging utility
-# Copyright (C) 2000-2003, 2005, 2008, 2011  NAKAMURA, Hiroshi <nahi@ruby-lang.org>.
+# Copyright (C) 2000-2003, 2005, 2008, 2011 NAKAMURA, Hiroshi <nahi@ruby-lang.org>.
 #
 # Documentation:: NAKAMURA, Hiroshi and Gavin Sinclair
 # License::
@@ -17,6 +17,7 @@ require_relative 'logger/formatter'
 require_relative 'logger/log_device'
 require_relative 'logger/severity'
 require_relative 'logger/errors'
+require_relative 'logger/buffer'
 
 # == Description
 #
@@ -462,9 +463,9 @@ class Logger
     if message.nil?
       if block_given?
         if block.arity > 0
-          buffer = StringIO.new
+          buffer = Buffer.new
           yield buffer
-          message = buffer.string
+          message = buffer.io.string
         else
           message = yield
         end

--- a/lib/logger/buffer.rb
+++ b/lib/logger/buffer.rb
@@ -2,8 +2,9 @@ require 'stringio'
 
 class Logger
   class Buffer
-    def initialize(io = StringIO.new, prefix = '[...]')
+    def initialize(io = StringIO.new, prefix = "\t")
       @io = io
+      @first = true
       @prefix = prefix
     end
     
@@ -11,7 +12,12 @@ class Logger
     
     def puts(*args)
       args.each do |arg|
-        @io.puts "#{@prefix}#{arg}"
+        if @first
+          @io.puts arg
+          @first = false
+        else
+          @io.puts "#{@prefix}#{arg}"
+        end
       end
     end
   end

--- a/lib/logger/buffer.rb
+++ b/lib/logger/buffer.rb
@@ -1,0 +1,18 @@
+require 'stringio'
+
+class Logger
+  class Buffer
+    def initialize(io = StringIO.new, prefix = '[...]')
+      @io = io
+      @prefix = prefix
+    end
+    
+    attr :io
+    
+    def puts(*args)
+      args.each do |arg|
+        @io.puts "#{@prefix}#{arg}"
+      end
+    end
+  end
+end

--- a/test/logger/test_buffer.rb
+++ b/test/logger/test_buffer.rb
@@ -1,0 +1,24 @@
+# coding: US-ASCII
+# frozen_string_literal: false
+require 'test/unit'
+require 'logger'
+
+class TestBuffer < Test::Unit::TestCase
+  def test_block_argument
+    r, w = IO.pipe
+    logger = Logger.new(w)
+    
+    logger.info do |buffer|
+      buffer.puts "Hello"
+      buffer.puts "World"
+    end
+    
+    IO.select([r], nil, nil, 0.1)
+    w.close
+    msg = r.read
+    r.close
+    
+    assert_include msg, "Hello"
+    assert_include msg, "World"
+  end
+end

--- a/test/logger/test_buffer.rb
+++ b/test/logger/test_buffer.rb
@@ -1,6 +1,6 @@
 # coding: US-ASCII
 # frozen_string_literal: false
-require 'test/unit'
+require_relative '../helper'
 require 'logger'
 
 class TestBuffer < Test::Unit::TestCase


### PR DESCRIPTION
The original PR got broken because I moved a branch from `ioquatix/logger` to `ruby/logger` and GitHub stopped updating it with my commits (since original repo is gone). So, I recreated it with branch from `ruby/logger#buffer`.

Previous discussion: https://github.com/ruby/logger/pull/14