### PR TITLE
Enable `frozen_string_literal: true` in `logger.rb`.

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 # logger.rb - simple logging utility
 # Copyright (C) 2000-2003, 2005, 2008, 2011  NAKAMURA, Hiroshi <nahi@ruby-lang.org>.
 #


### PR DESCRIPTION
Is there any reason not to do this?