### PR TITLE
Fix testing example to use --name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Advanced Development Tips
 
-### Run tests that defined on a specific line
+### Filter test method names
 
-`--location` option is available as:
+`--name` option is available as:
 
 ```
-ruby test/logger/test_logger.rb --location 40
+ruby test/logger/test_logger.rb --name test_lshift
 ```
 
 ## Contributing


### PR DESCRIPTION
Fix https://github.com/ruby/logger/issues/21.

The `test-unit` gem has `--location` option, but the customized test-unit like library on this repo did not have the option.

I want to use `test-unit` gem instead of the library on this repo, but it will be done somedays (PR is welcome)