### PR TITLE
[wip] Revert frozen_string_literal: true

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 # logger.rb - simple logging utility
 # Copyright (C) 2000-2003, 2005, 2008, 2011  NAKAMURA, Hiroshi <nahi@ruby-lang.org>.
 #

--- a/lib/logger/version.rb
+++ b/lib/logger/version.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class Logger
-  VERSION = "1.3.0"
+  VERSION = "1.3.0".freeze
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/11473#note-53

> So I officially abandon making frozen-string-literals default (for Ruby3).

Moving to use `frozen_string_literal: true` is opposite for going to the future.