### PR TITLE
Set filename when initializing logger with a File object

### DIFF
--- a/lib/logger/log_device.rb
+++ b/lib/logger/log_device.rb
@@ -78,6 +78,9 @@ class Logger
     def set_dev(log)
       if log.respond_to?(:write) and log.respond_to?(:close)
         @dev = log
+        if log.respond_to?(:path)
+          @filename = log.path
+        end
       else
         @dev = open_logfile(log)
         @dev.sync = true

--- a/test/logger/test_logdevice.rb
+++ b/test/logger/test_logdevice.rb
@@ -60,6 +60,21 @@ class TestLogDevice < Test::Unit::TestCase
     ensure
       logdev.close
     end
+    # logfile object with path
+    tempfile = Tempfile.new("logger")
+    tempfile.sync = true
+    logdev = d(tempfile)
+    begin
+      logdev.write('world')
+      logfile = File.read(tempfile.path)
+      assert_equal(1, logfile.split(/\n/).size)
+      assert_match(/^world$/, logfile)
+      assert_equal(tempfile.path, logdev.filename)
+    ensure
+      logdev.close
+      File.unlink(tempfile)
+      tempfile.close(true)
+    end
   end
 
   def test_write


### PR DESCRIPTION
This should allow reopen to work.  Requested in ruby issue #14595.