### PR TITLE
Backport test library from ruby core directly.

### DIFF
--- a/test/lib/core_assertions.rb
+++ b/test/lib/core_assertions.rb
@@ -1,10 +1,36 @@
 # frozen_string_literal: true
 
-require_relative 'envutil'
-
 module Test
   module Unit
     module CoreAssertions
+      if defined?(MiniTest)
+        require_relative '../../envutil'
+        # for ruby core testing
+        include MiniTest::Assertions
+      else
+        require 'pp'
+        require_relative 'envutil'
+        include Test::Unit::Assertions
+
+        def _assertions= n # :nodoc:
+          @_assertions = n
+        end
+
+        def _assertions # :nodoc:
+          @_assertions ||= 0
+        end
+
+        ##
+        # Returns a proc that will output +msg+ along with the default message.
+
+        def message msg = nil, ending = nil, &default
+          proc {
+            msg = msg.call.chomp(".") if Proc === msg
+            custom_message = "#{msg}.\n" unless msg.nil? or msg.to_s.empty?
+            "#{custom_message}#{default.call}#{ending || "."}"
+          }
+        end
+      end
 
       def mu_pp(obj) #:nodoc:
         obj.pretty_inspect.chomp
@@ -98,7 +124,7 @@ module Test
         end
         src = <<eom
 # -*- coding: #{line += __LINE__; src.encoding}; -*-
-  require #{__dir__.dump};include Test::Unit::Assertions
+  require "test/unit";include Test::Unit::Assertions;require #{(__dir__ + "/core_assertions").dump};include Test::Unit::CoreAssertions
   END {
     puts [Marshal.dump($!)].pack('m'), "assertions=\#{self._assertions}"
   }
@@ -107,6 +133,7 @@ module Test
     @@stop_auto_run = true
   end
 eom
+
         args = args.dup
         args.insert((Hash === args.first ? 1 : 0), "-w", "--disable=gems", *$:.map {|l| "-I#{l}"})
         stdout, stderr, status = EnvUtil.invoke_ruby(args, src, true, true, **opt)

--- a/test/lib/core_assertions.rb
+++ b/test/lib/core_assertions.rb
@@ -1,36 +1,17 @@
 # frozen_string_literal: true
-require 'test/unit'
-require 'pp'
+
 require_relative 'envutil'
 
 module Test
   module Unit
-    module Assertions
+    module CoreAssertions
+
       def mu_pp(obj) #:nodoc:
         obj.pretty_inspect.chomp
       end
 
-      def _assertions= n # :nodoc:
-        @_assertions = n
-      end
-
-      def _assertions # :nodoc:
-        @_assertions ||= 0
-      end
-
       def assert_file
         AssertFile
-      end
-
-      ##
-      # Returns a proc that will output +msg+ along with the default message.
-
-      def message msg = nil, ending = nil, &default
-        proc {
-          msg = msg.call.chomp(".") if Proc === msg
-          custom_message = "#{msg}.\n" unless msg.nil? or msg.to_s.empty?
-          "#{custom_message}#{default.call}#{ending || "."}"
-        }
       end
 
       FailDesc = proc do |status, message = "", out = ""|
@@ -69,7 +50,7 @@ module Test
       end
 
       def assert_in_out_err(args, test_stdin = "", test_stdout = [], test_stderr = [], message = nil,
-        success: nil, **opt)
+                            success: nil, **opt)
         args = Array(args).dup
         args.insert((Hash === args[0] ? 1 : 0), '--disable=gems')
         stdout, stderr, status = EnvUtil.invoke_ruby(args, test_stdin, true, true, **opt)
@@ -117,7 +98,7 @@ module Test
         end
         src = <<eom
 # -*- coding: #{line += __LINE__; src.encoding}; -*-
-  require #{(__dir__ + "/assertions").dump};include Test::Unit::Assertions
+  require #{__dir__.dump};include Test::Unit::Assertions
   END {
     puts [Marshal.dump($!)].pack('m'), "assertions=\#{self._assertions}"
   }
@@ -126,7 +107,6 @@ module Test
     @@stop_auto_run = true
   end
 eom
-
         args = args.dup
         args.insert((Hash === args.first ? 1 : 0), "-w", "--disable=gems", *$:.map {|l| "-I#{l}"})
         stdout, stderr, status = EnvUtil.invoke_ruby(args, src, true, true, **opt)
@@ -160,7 +140,7 @@ eom
       end
 
       class << (AssertFile = Struct.new(:failure_message).new)
-        include Assertions
+        include CoreAssertions
         def assert_file_predicate(predicate, *args)
           if /\Anot_/ =~ predicate
             predicate = $'
@@ -229,6 +209,7 @@ eom
         assert(all.pass?, message(msg) {all.message.chomp(".")})
       end
       alias all_assertions assert_all_assertions
+
     end
   end
 end

--- a/test/lib/envutil.rb
+++ b/test/lib/envutil.rb
@@ -45,7 +45,7 @@ module EnvUtil
   RUBYLIB = ENV["RUBYLIB"]
 
   class << self
-    attr_accessor :subprocess_timeout_scale
+    attr_accessor :timeout_scale
     attr_reader :original_internal_encoding, :original_external_encoding,
                 :original_verbose
 
@@ -57,13 +57,55 @@ module EnvUtil
   end
 
   def apply_timeout_scale(t)
-    if scale = EnvUtil.subprocess_timeout_scale
+    if scale = EnvUtil.timeout_scale
       t * scale
     else
       t
     end
   end
   module_function :apply_timeout_scale
+
+  def timeout(sec, klass = nil, message = nil, &blk)
+    return yield(sec) if sec == nil or sec.zero?
+    sec = apply_timeout_scale(sec)
+    Timeout.timeout(sec, klass, message, &blk)
+  end
+  module_function :timeout
+
+  def terminate(pid, signal = :TERM, pgroup = nil, reprieve = 1)
+    reprieve = apply_timeout_scale(reprieve) if reprieve
+
+    signals = Array(signal).select do |sig|
+      DEFAULT_SIGNALS[sig.to_s] or
+        DEFAULT_SIGNALS[Signal.signame(sig)] rescue false
+    end
+    signals |= [:ABRT, :KILL]
+    case pgroup
+    when 0, true
+      pgroup = -pid
+    when nil, false
+      pgroup = pid
+    end
+    while signal = signals.shift
+      begin
+        Process.kill signal, pgroup
+      rescue Errno::EINVAL
+        next
+      rescue Errno::ESRCH
+        break
+      end
+      if signals.empty? or !reprieve
+        Process.wait(pid)
+      else
+        begin
+          Timeout.timeout(reprieve) {Process.wait(pid)}
+        rescue Timeout::Error
+        end
+      end
+    end
+    $?
+  end
+  module_function :terminate
 
   def invoke_ruby(args, stdin_data = "", capture_stdout = false, capture_stderr = false,
                   encoding: nil, timeout: 10, reprieve: 1, timeout_error: Timeout::Error,
@@ -72,7 +114,6 @@ module EnvUtil
                   rubybin: EnvUtil.rubybin, precommand: nil,
                   **opt)
     timeout = apply_timeout_scale(timeout)
-    reprieve = apply_timeout_scale(reprieve) if reprieve
 
     in_c, in_p = IO.pipe
     out_p, out_c = IO.pipe if capture_stdout
@@ -108,35 +149,7 @@ module EnvUtil
       if (!th_stdout || th_stdout.join(timeout)) && (!th_stderr || th_stderr.join(timeout))
         timeout_error = nil
       else
-        signals = Array(signal).select do |sig|
-          DEFAULT_SIGNALS[sig.to_s] or
-            DEFAULT_SIGNALS[Signal.signame(sig)] rescue false
-        end
-        signals |= [:ABRT, :KILL]
-        case pgroup = opt[:pgroup]
-        when 0, true
-          pgroup = -pid
-        when nil, false
-          pgroup = pid
-        end
-        while signal = signals.shift
-          begin
-            Process.kill signal, pgroup
-          rescue Errno::EINVAL
-            next
-          rescue Errno::ESRCH
-            break
-          end
-          if signals.empty? or !reprieve
-            Process.wait(pid)
-          else
-            begin
-              Timeout.timeout(reprieve) {Process.wait(pid)}
-            rescue Timeout::Error
-            end
-          end
-        end
-        status = $?
+        status = terminate(pid, signal, opt[:pgroup], reprieve)
       end
       stdout = th_stdout.value if capture_stdout
       stderr = th_stderr.value if capture_stderr && capture_stderr != :merge_to_stdout

--- a/test/logger/helper.rb
+++ b/test/logger/helper.rb
@@ -3,4 +3,6 @@ $LOAD_PATH.unshift File.join(ROOT_DIR, 'lib') # to use logger in this repo inste
 $LOAD_PATH.unshift File.join(ROOT_DIR, 'test', 'lib') # to use custom test-unit in this repo
 require 'logger'
 require 'test/unit'
-require 'assertions'
+require 'core_assertions'
+
+Test::Unit::TestCase.include Test::Unit::CoreAssertions

--- a/test/logger/test_logdevice.rb
+++ b/test/logger/test_logdevice.rb
@@ -1,6 +1,6 @@
 # coding: US-ASCII
 # frozen_string_literal: false
-require_relative '../helper'
+require_relative 'helper'
 require 'tempfile'
 require 'tmpdir'
 

--- a/test/logger/test_logger.rb
+++ b/test/logger/test_logger.rb
@@ -1,6 +1,6 @@
 # coding: US-ASCII
 # frozen_string_literal: false
-require_relative '../helper'
+require_relative 'helper'
 require 'tempfile'
 
 class TestLogger < Test::Unit::TestCase

--- a/test/logger/test_severity.rb
+++ b/test/logger/test_severity.rb
@@ -1,6 +1,6 @@
 # coding: US-ASCII
 # frozen_string_literal: false
-require_relative '../helper'
+require_relative 'helper'
 
 class TestLoggerSeverity < Test::Unit::TestCase
   def test_enum


### PR DESCRIPTION
This pull request further updates from https://github.com/ruby/logger/pull/32.

1. Backport from https://github.com/ruby/ruby/blob/master/tool/lib/test/unit/core_assertions.rb. and update the some of workarounds for default gems.
2. Resolve inconsistency directory structure from ruby core repository for `helper.rb`

