### PR TITLE
Avoid creating [] and "" when logging an Exception that has no backtrace

### DIFF
--- a/lib/logger/formatter.rb
+++ b/lib/logger/formatter.rb
@@ -27,7 +27,7 @@ class Logger
       when ::String
         msg
       when ::Exception
-        "#{ msg.message } (#{ msg.class })\n#{ (msg.backtrace || []).join("\n") }"
+        "#{ msg.message } (#{ msg.class })\n#{ msg.backtrace.join("\n") if msg.backtrace }"
       else
         msg.inspect
       end


### PR DESCRIPTION
This patch reduces object allocations when logging an Exception that has no backtrace.