### PR TITLE
Add reraise_exception_classes keyword argument to Logger and LogDevice

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -574,10 +574,14 @@ class Logger
   # - +shift_period_suffix+: sets the format for the filename suffix
   #   for periodic log file rotation; default is <tt>'%Y%m%d'</tt>.
   #   See {Periodic Rotation}[rdoc-ref:Logger@Periodic+Rotation].
+  # - +reraise_write_errors+: An array of exception classes, which will
+  #   be reraised if there is an error when writing to the log device.
+  #   The default is to swallow all exceptions raised.
   #
   def initialize(logdev, shift_age = 0, shift_size = 1048576, level: DEBUG,
                  progname: nil, formatter: nil, datetime_format: nil,
-                 binmode: false, shift_period_suffix: '%Y%m%d')
+                 binmode: false, shift_period_suffix: '%Y%m%d',
+                 reraise_write_errors: [])
     self.level = level
     self.progname = progname
     @default_formatter = Formatter.new
@@ -589,7 +593,8 @@ class Logger
       @logdev = LogDevice.new(logdev, shift_age: shift_age,
         shift_size: shift_size,
         shift_period_suffix: shift_period_suffix,
-        binmode: binmode)
+        binmode: binmode,
+        reraise_write_errors: reraise_write_errors)
     end
   end
 

--- a/test/logger/test_logger.rb
+++ b/test/logger/test_logger.rb
@@ -113,6 +113,15 @@ class TestLogger < Test::Unit::TestCase
     assert_raise(ArgumentError) { @logger.level = 'something_wrong' }
   end
 
+  def test_reraise_write_errors
+    c = Object.new
+    e = Class.new(StandardError)
+    c.define_singleton_method(:write){|*| raise e}
+    c.define_singleton_method(:close){}
+    logger = Logger.new(c, :reraise_write_errors=>[e])
+    assert_raise(e) { logger.warn('foo') }
+  end
+
   def test_progname
     assert_nil(@logger.progname)
     @logger.progname = "name"


### PR DESCRIPTION
This allows the user to specify exception classes to treat as regular
exceptions instead of being swallowed.  Among other things, it is
useful for having Logger work with Timeout when having Timeout raise
a specific subclass.

Fixes Ruby Bug 9115. https://bugs.ruby-lang.org/issues/9115