### PR TITLE
Enable more timezone tests on OpenBSD

### DIFF
--- a/test/logger/test_logdevice.rb
+++ b/test/logger/test_logdevice.rb
@@ -490,7 +490,7 @@ class TestLogDevice < Test::Unit::TestCase
     end
   end
 
-  env_tz_works = /linux|darwin|freebsd/ =~ RUBY_PLATFORM # borrow from test/ruby/test_time_tz.rb
+  env_tz_works = /linux|darwin|freebsd|openbsd/ =~ RUBY_PLATFORM # borrow from test/ruby/test_time_tz.rb
 
   def test_shifting_weekly
     Dir.mktmpdir do |tmpdir|


### PR DESCRIPTION
I recently updated `test/ruby/test_time_tz.rb` to enable the related tests on OpenBSD (as they all pass).  All of logger's tests pass with this enabled on OpenBSD.