### PR TITLE
Honor Logger#level overrides

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -304,35 +304,35 @@ class Logger
 
   # Returns +true+ iff the current severity level allows for the printing of
   # +DEBUG+ messages.
-  def debug?; @level <= DEBUG; end
+  def debug?; level <= DEBUG; end
 
   # Sets the severity to DEBUG.
   def debug!; self.level = DEBUG; end
 
   # Returns +true+ iff the current severity level allows for the printing of
   # +INFO+ messages.
-  def info?; @level <= INFO; end
+  def info?; level <= INFO; end
 
   # Sets the severity to INFO.
   def info!; self.level = INFO; end
 
   # Returns +true+ iff the current severity level allows for the printing of
   # +WARN+ messages.
-  def warn?; @level <= WARN; end
+  def warn?; level <= WARN; end
 
   # Sets the severity to WARN.
   def warn!; self.level = WARN; end
 
   # Returns +true+ iff the current severity level allows for the printing of
   # +ERROR+ messages.
-  def error?; @level <= ERROR; end
+  def error?; level <= ERROR; end
 
   # Sets the severity to ERROR.
   def error!; self.level = ERROR; end
 
   # Returns +true+ iff the current severity level allows for the printing of
   # +FATAL+ messages.
-  def fatal?; @level <= FATAL; end
+  def fatal?; level <= FATAL; end
 
   # Sets the severity to FATAL.
   def fatal!; self.level = FATAL; end
@@ -456,7 +456,7 @@ class Logger
   #
   def add(severity, message = nil, progname = nil)
     severity ||= UNKNOWN
-    if @logdev.nil? or severity < @level
+    if @logdev.nil? or severity < level
       return true
     end
     if progname.nil?

--- a/test/logger/test_logger.rb
+++ b/test/logger/test_logger.rb
@@ -363,4 +363,19 @@ class TestLogger < Test::Unit::TestCase
     r.close
     assert_equal("msg2\n\n", msg)
   end
+
+  class CustomLogger < Logger
+    def level
+      INFO
+    end
+  end
+
+  def test_overriding_level
+    logger = CustomLogger.new(nil)
+    log = log(logger, :info) { "msg" }
+    assert_equal "msg\n", log.msg
+    #
+    log = log(logger, :debug) { "msg" }
+    assert_nil log.msg
+  end
 end


### PR DESCRIPTION
We attempt to override `Logger#level` in Rails’s Logger subclass to [allow setting a different level per thread](https://github.com/rails/rails/blob/d03d6fc33b4e9629e3e969c18bda4bdcd3c01c90/activesupport/lib/active_support/logger_thread_safe_level.rb) (and thus per request). But `Logger#add` checks the new message’s severity against the `@level` instance variable, so overriding `#level` doesn’t have the intended effect. (We also prepend a check against `#level` to `#add`, so you can only set the thread-local level greater than or equal to `@level`, not less. We’d like to allow setting any thread-local level.)

This patch modifies `Logger#add` to check `#level` so that third-party loggers can customize how the current level is determined without needing to reimplement `#add` or juggle multiple underlying Logger instances.