### PR TITLE
Raise ArgumentError for invalid shift_age

### DIFF
--- a/lib/logger/period.rb
+++ b/lib/logger/period.rb
@@ -15,8 +15,10 @@ class Logger
       when 'monthly'
         t = Time.mktime(now.year, now.month, 1) + SiD * 32
         return Time.mktime(t.year, t.month, 1)
-      else
+      when 'now', 'everytime'
         return now
+      else
+        raise ArgumentError, "invalid :shift_age #{shift_age.inspect}, should be daily, weekly, monthly, or everytime"
       end
       if t.hour.nonzero? or t.min.nonzero? or t.sec.nonzero?
         hour = t.hour
@@ -34,8 +36,10 @@ class Logger
         t = Time.mktime(now.year, now.month, now.mday) - (SiD * now.wday + SiD / 2)
       when 'monthly'
         t = Time.mktime(now.year, now.month, 1) - SiD / 2
-      else
+      when 'now', 'everytime'
         return now
+      else
+        raise ArgumentError, "invalid :shift_age #{shift_age.inspect}, should be daily, weekly, monthly, or everytime"
       end
       Time.mktime(t.year, t.month, t.mday, 23, 59, 59)
     end

--- a/test/logger/test_logdevice.rb
+++ b/test/logger/test_logdevice.rb
@@ -275,8 +275,12 @@ class TestLogDevice < Test::Unit::TestCase
     logger.close
   end
 
+  def test_invalid_shifting_age
+    assert_raise(ArgumentError) { Logger.new(@filename, 'invalid') }
+    assert_raise(ArgumentError) { Logger::Period.previous_period_end(Time.now, 'invalid') }
+  end
+
   def test_shifting_age
-    # shift_age other than 'daily', 'weekly', and 'monthly' means 'everytime'
     yyyymmdd = Time.now.strftime("%Y%m%d")
     filename1 = @filename + ".#{yyyymmdd}"
     filename2 = @filename + ".#{yyyymmdd}.1"
@@ -311,7 +315,6 @@ class TestLogDevice < Test::Unit::TestCase
   end
 
   def test_shifting_period_suffix
-    # shift_age other than 'daily', 'weekly', and 'monthly' means 'everytime'
     ['%Y%m%d', '%Y-%m-%d', '%Y'].each do |format|
       if format == '%Y%m%d' # default
         logger = Logger.new(@filename, 'now', 1048576)


### PR DESCRIPTION
Consider 'now' and 'everytime' as valid values for the previous behavior of rotating every time.

Fixes Ruby Bug 15977