### PR TITLE
Let File::NULL ("/dev/null", "NUL" etc.) be considered a nil log device

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -385,7 +385,7 @@ class Logger
     self.datetime_format = datetime_format
     self.formatter = formatter
     @logdev = nil
-    if logdev
+    if logdev && logdev != File::NULL
       @logdev = LogDevice.new(logdev, shift_age: shift_age,
         shift_size: shift_size,
         shift_period_suffix: shift_period_suffix,

--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -410,7 +410,7 @@ class Logger
   # Reopen a log device.
   #
   def reopen(logdev = nil)
-    @logdev.reopen(logdev)
+    @logdev&.reopen(logdev)
     self
   end
 

--- a/test/logger/test_logger.rb
+++ b/test/logger/test_logger.rb
@@ -216,6 +216,13 @@ class TestLogger < Test::Unit::TestCase
     assert_equal(STDOUT, logger.instance_variable_get(:@logdev).dev)
   end
 
+  def test_reopen_nil_logdevice
+    logger = Logger.new(File::NULL)
+    assert_nothing_raised do
+      logger.reopen(STDOUT)
+    end
+  end
+
   def test_add
     logger = Logger.new(nil)
     logger.progname = "my_progname"

--- a/test/logger/test_logger.rb
+++ b/test/logger/test_logger.rb
@@ -378,4 +378,9 @@ class TestLogger < Test::Unit::TestCase
     log = log(logger, :debug) { "msg" }
     assert_nil log.msg
   end
+
+  def test_does_not_instantiate_log_device_for_File_NULL
+    l = Logger.new(File::NULL)
+    assert_nil(l.instance_variable_get(:@logdev))
+  end
 end


### PR DESCRIPTION
References erroneous upstream PR https://github.com/ruby/ruby/pull/2989

I noticed on a `Logger` instance with `File::NULL` or `/dev/null` as log device arguments a lot of formatting and other overhead still occurs, with the expected result essentially still being "I want to blackhole these logs":

```
GC: 130 (7.40%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       348  (19.8%)         348  (19.8%)     Logger::Formatter#format_datetime
       614  (35.0%)         169   (9.6%)     Logger::Formatter#call
       395  (22.5%)         152   (8.7%)     Logger::LogDevice#write
```

The logger was configured as `Logger.new(File::NULL)`.