### PR TITLE
Mention behavior when logdev is a nil in the document

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -349,8 +349,8 @@ class Logger
   # === Args
   #
   # +logdev+::
-  #   The log device.  This is a filename (String) or IO object (typically
-  #   +STDOUT+, +STDERR+, or an open file).
+  #   The log device.  This is a filename (String), IO object (typically
+  #   +STDOUT+, +STDERR+, or an open file) or nil (it writes nothing).
   # +shift_age+::
   #   Number of old log files to keep, *or* frequency of rotation (+daily+,
   #   +weekly+ or +monthly+). Default value is 0, which disables log file

--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -350,7 +350,8 @@ class Logger
   #
   # +logdev+::
   #   The log device.  This is a filename (String), IO object (typically
-  #   +STDOUT+, +STDERR+, or an open file) or nil (it writes nothing).
+  #   +STDOUT+, +STDERR+, or an open file), +nil+ (it writes nothing) or
+  #   +File::NULL+ (same as +nil+).
   # +shift_age+::
   #   Number of old log files to keep, *or* frequency of rotation (+daily+,
   #   +weekly+ or +monthly+). Default value is 0, which disables log file


### PR DESCRIPTION
We can make a logger that does nothing by `Logger.new(nil)`, but it is not documented.
This pull request adds a mention of the behavior.


