### PR TITLE
Consider cygwin a Windows platform

### DIFF
--- a/lib/logger/log_device.rb
+++ b/lib/logger/log_device.rb
@@ -135,7 +135,7 @@ class Logger
       end
     end
 
-    if /mswin|mingw/ =~ RUBY_PLATFORM
+    if /mswin|mingw|cygwin/ =~ RUBY_PLATFORM
       def lock_shift_log
         yield
       end

--- a/test/logger/test_logdevice.rb
+++ b/test/logger/test_logdevice.rb
@@ -451,7 +451,7 @@ class TestLogDevice < Test::Unit::TestCase
     end
   ensure
     logdev0.close
-  end unless /mswin|mingw/ =~ RUBY_PLATFORM
+  end unless /mswin|mingw|cygwin/ =~ RUBY_PLATFORM
 
   def test_shifting_midnight
     Dir.mktmpdir do |tmpdir|


### PR DESCRIPTION
This should fix Ruby Bug 12468 (https://bugs.ruby-lang.org/issues/12468)