### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ matrix:
     - rvm: 2.4
     - rvm: 2.5
     - rvm: 2.6
-    - rvm: 2.6
+    - rvm: 2.7
+    - rvm: 2.7
       os: osx
     - rvm: ruby-head
   allow_failures:

--- a/logger.gemspec
+++ b/logger.gemspec
@@ -1,12 +1,12 @@
-begin
-  require_relative "lib/logger/version"
-rescue LoadError # Fallback to load version file in ruby core repository
-  require_relative "version"
+version_module = Module.new do
+  version_rb = File.join(__dir__, 'lib', 'logger', 'version.rb')
+  version_rb = File.join(__dir__, 'version.rb') unless File.exist?(version_rb)
+  module_eval(File.read(version_rb), version_rb)
 end
 
 Gem::Specification.new do |spec|
   spec.name          = "logger"
-  spec.version       = Logger::VERSION
+  spec.version       = version_module::Logger::VERSION
   spec.authors       = ["Naotoshi Seo", "SHIBATA Hiroshi"]
   spec.email         = ["sonots@gmail.com", "hsbt@ruby-lang.org"]
 

--- a/test/lib/envutil.rb
+++ b/test/lib/envutil.rb
@@ -304,7 +304,6 @@ if defined?(RbConfig)
     end
     dir = File.dirname(ruby)
     CONFIG['bindir'] = dir
-    Gem::ConfigMap[:bindir] = dir if defined?(Gem::ConfigMap)
   end
 end
 


### PR DESCRIPTION
- copied version loading hack from https://github.com/ruby/psych/blob/master/psych.gemspec
- fixed `envutil.rb` due to deprecation warnings
- added 2.7 to the CI matrix

Closes #48 