### PR TITLE
Replace "iff" with "if and only if"

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -302,35 +302,35 @@ class Logger
   alias sev_threshold level
   alias sev_threshold= level=
 
-  # Returns +true+ iff the current severity level allows for the printing of
+  # Returns +true+ if and only if the current severity level allows for the printing of
   # +DEBUG+ messages.
   def debug?; level <= DEBUG; end
 
   # Sets the severity to DEBUG.
   def debug!; self.level = DEBUG; end
 
-  # Returns +true+ iff the current severity level allows for the printing of
+  # Returns +true+ if and only if the current severity level allows for the printing of
   # +INFO+ messages.
   def info?; level <= INFO; end
 
   # Sets the severity to INFO.
   def info!; self.level = INFO; end
 
-  # Returns +true+ iff the current severity level allows for the printing of
+  # Returns +true+ if and only if the current severity level allows for the printing of
   # +WARN+ messages.
   def warn?; level <= WARN; end
 
   # Sets the severity to WARN.
   def warn!; self.level = WARN; end
 
-  # Returns +true+ iff the current severity level allows for the printing of
+  # Returns +true+ if and only if the current severity level allows for the printing of
   # +ERROR+ messages.
   def error?; level <= ERROR; end
 
   # Sets the severity to ERROR.
   def error!; self.level = ERROR; end
 
-  # Returns +true+ iff the current severity level allows for the printing of
+  # Returns +true+ if and only if the current severity level allows for the printing of
   # +FATAL+ messages.
   def fatal?; level <= FATAL; end
 


### PR DESCRIPTION
iff means if and only if, but readers without that knowledge might assume this to be a spelling mistake. To me, this seems like exclusionary language that is unnecessary. Simply using "if and only if" instead should suffice.

Logger changes from https://github.com/ruby/ruby/pull/4035. I had originally issued the patch on ruby/ruby to fix this in the docs. I assume making the change here will find its way into the docs for future releases.