### PR TITLE
allow setting shift variables in LogDevice when using reopen

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -621,8 +621,9 @@ class Logger
   #   #  "E, [2022-05-12T14:21:27.596726 #22428] ERROR -- : one\n",
   #   #  "E, [2022-05-12T14:23:05.847241 #22428] ERROR -- : three\n"]
   #
-  def reopen(logdev = nil)
-    @logdev&.reopen(logdev)
+  def reopen(logdev = nil, shift_age = nil, shift_size = nil, shift_period_suffix: nil, binmode: nil)
+    @logdev&.reopen(logdev, shift_age: shift_age, shift_size: shift_size,
+                    shift_period_suffix: shift_period_suffix, binmode: binmode)
     self
   end
 

--- a/lib/logger/log_device.rb
+++ b/lib/logger/log_device.rb
@@ -86,9 +86,9 @@ class Logger
     end
 
     def set_file(shift_age, shift_size, shift_period_suffix)
-      @shift_age = shift_age.nil? ? @shift_age || 7 : shift_age
-      @shift_size = shift_size.nil? ? @shift_size || 1048576 : shift_size
-      @shift_period_suffix = shift_period_suffix.nil? ? @shift_period_suffix || '%Y%m%d' : shift_period_suffix
+      @shift_age = shift_age || @shift_age || 7
+      @shift_size = shift_size || @shift_size || 1048576
+      @shift_period_suffix = shift_period_suffix || @shift_period_suffix || '%Y%m%d'
 
       unless @shift_age.is_a?(Integer)
         base_time = @dev.respond_to?(:stat) ? @dev.stat.mtime : Time.now

--- a/test/logger/test_logdevice.rb
+++ b/test/logger/test_logdevice.rb
@@ -205,6 +205,83 @@ class TestLogDevice < Test::Unit::TestCase
     end
   end
 
+  def test_shifting_size_with_reopen
+    tmpfile = Tempfile.new([File.basename(__FILE__, '.*'), '_1.log'])
+    logfile = tmpfile.path
+    logfile0 = logfile + '.0'
+    logfile1 = logfile + '.1'
+    logfile2 = logfile + '.2'
+    logfile3 = logfile + '.3'
+    tmpfile.close(true)
+    File.unlink(logfile) if File.exist?(logfile)
+    File.unlink(logfile0) if File.exist?(logfile0)
+    File.unlink(logfile1) if File.exist?(logfile1)
+    File.unlink(logfile2) if File.exist?(logfile2)
+
+    logger = Logger.new(STDERR)
+    logger.reopen(logfile, 4, 100)
+
+    logger.error("0" * 15)
+    assert_file.exist?(logfile)
+    assert_file.not_exist?(logfile0)
+    logger.error("0" * 15)
+    assert_file.exist?(logfile0)
+    assert_file.not_exist?(logfile1)
+    logger.error("0" * 15)
+    assert_file.exist?(logfile1)
+    assert_file.not_exist?(logfile2)
+    logger.error("0" * 15)
+    assert_file.exist?(logfile2)
+    assert_file.not_exist?(logfile3)
+    logger.error("0" * 15)
+    assert_file.not_exist?(logfile3)
+    logger.error("0" * 15)
+    assert_file.not_exist?(logfile3)
+    logger.close
+    File.unlink(logfile)
+    File.unlink(logfile0)
+    File.unlink(logfile1)
+    File.unlink(logfile2)
+
+    tmpfile = Tempfile.new([File.basename(__FILE__, '.*'), '_2.log'])
+    logfile = tmpfile.path
+    logfile0 = logfile + '.0'
+    logfile1 = logfile + '.1'
+    logfile2 = logfile + '.2'
+    logfile3 = logfile + '.3'
+    tmpfile.close(true)
+    logger = Logger.new(logfile, 4, 150)
+    logger.error("0" * 15)
+    assert_file.exist?(logfile)
+    assert_file.not_exist?(logfile0)
+    logger.error("0" * 15)
+    assert_file.not_exist?(logfile0)
+    logger.error("0" * 15)
+    assert_file.exist?(logfile0)
+    assert_file.not_exist?(logfile1)
+    logger.error("0" * 15)
+    assert_file.not_exist?(logfile1)
+    logger.error("0" * 15)
+    assert_file.exist?(logfile1)
+    assert_file.not_exist?(logfile2)
+    logger.error("0" * 15)
+    assert_file.not_exist?(logfile2)
+    logger.error("0" * 15)
+    assert_file.exist?(logfile2)
+    assert_file.not_exist?(logfile3)
+    logger.error("0" * 15)
+    assert_file.not_exist?(logfile3)
+    logger.error("0" * 15)
+    assert_file.not_exist?(logfile3)
+    logger.error("0" * 15)
+    assert_file.not_exist?(logfile3)
+    logger.close
+    File.unlink(logfile)
+    File.unlink(logfile0)
+    File.unlink(logfile1)
+    File.unlink(logfile2)
+  end
+
   def test_shifting_size
     tmpfile = Tempfile.new([File.basename(__FILE__, '.*'), '_1.log'])
     logfile = tmpfile.path


### PR DESCRIPTION
This addresses the issue I raised in #55 

The code in this PR allows setting parameters applicable to a log file in `LogDevice#reopen` as well as during initialization.

I only added the one test to demonstrate the functionality; please let me know what all you would like done here. Should I just copy/paste all of the applicable tests while replacing the constructor code with [these 2 lines](https://github.com/ruby/logger/compare/master...titusfortner:reopen_shifts?expand=1#diff-2509e01a96e40294a3547b0049c17f7cf40614c3a9e91dbf8cabf3edca3c1defR205-R206)? Should I put it in a separate test file?