### PR TITLE
Allow setting datetime_format for custom formatters.

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -277,12 +277,12 @@ class Logger
   #
   # +datetime_format+:: A string suitable for passing to +strftime+.
   def datetime_format=(datetime_format)
-    @default_formatter.datetime_format = datetime_format
+    (@formatter || @default_formatter).datetime_format = datetime_format
   end
 
   # Returns the date format being used.  See #datetime_format=
   def datetime_format
-    @default_formatter.datetime_format
+    (@formatter || @default_formatter).datetime_format
   end
 
   # Logging formatter, as a +Proc+ that will take four arguments and

--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -277,12 +277,18 @@ class Logger
   #
   # +datetime_format+:: A string suitable for passing to +strftime+.
   def datetime_format=(datetime_format)
-    (@formatter || @default_formatter).datetime_format = datetime_format
+    formatter = @formatter || @default_formatter
+    return Kernel.warn("Formatter can't set datetime format") unless formatter.respond_to?(:datetime_format=)
+
+    formatter.datetime_format = datetime_format
   end
 
   # Returns the date format being used.  See #datetime_format=
   def datetime_format
-    (@formatter || @default_formatter).datetime_format
+    formatter = @formatter || @default_formatter
+    return Kernel.warn("Formatter can't provide datetime format") unless formatter.respond_to?(:datetime_format)
+
+    formatter.datetime_format
   end
 
   # Logging formatter, as a +Proc+ that will take four arguments and
@@ -383,8 +389,8 @@ class Logger
     self.level = level
     self.progname = progname
     @default_formatter = Formatter.new
-    self.datetime_format = datetime_format
     self.formatter = formatter
+    self.datetime_format = datetime_format
     @logdev = nil
     if logdev && logdev != File::NULL
       @logdev = LogDevice.new(logdev, shift_age: shift_age,

--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -278,7 +278,7 @@ class Logger
   # +datetime_format+:: A string suitable for passing to +strftime+.
   def datetime_format=(datetime_format)
     formatter = @formatter || @default_formatter
-    return Kernel.warn("Formatter can't set datetime format") unless formatter.respond_to?(:datetime_format=)
+    return Warning.warn("WARNING: Logger Formatter can't set datetime format") unless formatter.respond_to?(:datetime_format=)
 
     formatter.datetime_format = datetime_format
   end
@@ -286,7 +286,7 @@ class Logger
   # Returns the date format being used.  See #datetime_format=
   def datetime_format
     formatter = @formatter || @default_formatter
-    return Kernel.warn("Formatter can't provide datetime format") unless formatter.respond_to?(:datetime_format)
+    return Warning.warn("WARNING: Logger Formatter can't provide datetime format") unless formatter.respond_to?(:datetime_format)
 
     formatter.datetime_format
   end

--- a/test/logger/test_logger.rb
+++ b/test/logger/test_logger.rb
@@ -123,8 +123,19 @@ class TestLogger < Test::Unit::TestCase
     verbose, $VERBOSE = $VERBOSE, false
     dummy = STDERR
     logger = Logger.new(dummy)
+    # with default formatter
     log = log_add(logger, INFO, "foo")
-    assert_match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\s*\d+ $/, log.datetime)
+    assert_match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\d\d\d\d\d $/, log.datetime)
+    logger.datetime_format = "%d%b%Y@%H:%M:%S"
+    log = log_add(logger, INFO, "foo")
+    assert_match(/^\d\d\w\w\w\d\d\d\d@\d\d:\d\d:\d\d$/, log.datetime)
+    logger.datetime_format = ""
+    log = log_add(logger, INFO, "foo")
+    assert_match(/^$/, log.datetime)
+    # with custom formatter
+    logger.formatter = Class.new(Logger::Formatter).new
+    log = log_add(logger, INFO, "foo")
+    assert_match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\d\d\d\d\d $/, log.datetime)
     logger.datetime_format = "%d%b%Y@%H:%M:%S"
     log = log_add(logger, INFO, "foo")
     assert_match(/^\d\d\w\w\w\d\d\d\d@\d\d:\d\d:\d\d$/, log.datetime)

--- a/test/logger/test_logger.rb
+++ b/test/logger/test_logger.rb
@@ -133,7 +133,7 @@ class TestLogger < Test::Unit::TestCase
     log = log_add(logger, INFO, "foo")
     assert_match(/^$/, log.datetime)
     # with custom formatter
-    logger.formatter = Class.new(Logger::Formatter).new
+    logger.formatter = Logger::Formatter.new
     log = log_add(logger, INFO, "foo")
     assert_match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\d\d\d\d\d $/, log.datetime)
     logger.datetime_format = "%d%b%Y@%H:%M:%S"
@@ -217,6 +217,17 @@ class TestLogger < Test::Unit::TestCase
     assert_match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\s*\d+ $/, log.datetime)
     # config
     logger = Logger.new(STDERR, datetime_format: "%d%b%Y@%H:%M:%S")
+    log = log_add(logger, INFO, "foo")
+    assert_match(/^\d\d\w\w\w\d\d\d\d@\d\d:\d\d:\d\d$/, log.datetime)
+  end
+
+  def test_initialize_with_formatter_and_datetime_format
+    # default
+    logger = Logger.new(STDERR)
+    log = log_add(logger, INFO, "foo")
+    assert_match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\s*\d+ $/, log.datetime)
+    # config
+    logger = Logger.new(STDERR, formatter: Logger::Formatter.new, datetime_format: "%d%b%Y@%H:%M:%S")
     log = log_add(logger, INFO, "foo")
     assert_match(/^\d\d\w\w\w\d\d\d\d@\d\d:\d\d:\d\d$/, log.datetime)
   end


### PR DESCRIPTION
If initialize a logger with a custom formatter provided and try to change `datetime_format`, changes will apply on the `@default_formatter` that is not used and this is confusing.
These changes will allow setting datetime_format for custom formatters.

Code example:
```ruby
# Define a custom formatter
class CustomFormatter < Logger::Formatter
  def call(severity, time, progname, msg)
    "#{severity}: #{format_datetime(time)} - #{msg}"
  end
end

# Current behavior

# Initialize logger with a custom formatter and datetime_format
logger = Logger.new(formatter: CustomFormatter.new, datetime_format: "%d%b%Y@%H:%M:%S")
logger.info('test')
# => INFO: 2021-07-19T04:45:02.454855 - test
# No datetime format changes

# Return default formatter for logger
logger.formatter = nil
logger.info('test')
# => I, [19Jul2021@04:46:56#1216878]  INFO -- : test
# Could see that datetime format changed on default formatter

# Initialize logger with a custom formatter and then set datetime_format
logger = Logger.new(formatter: CustomFormatter.new)
logger.datetime_format  = "%d%b%Y@%H:%M:%S"
logger.info('test')
# => INFO: 2021-07-19T04:48:05.855454 - test
# No datetime format changes

# Return default formatter for logger
logger.formatter = nil
logger.info('test')
# => I, [19Jul2021@04:49:39#1216878]  INFO -- : test
# Could see that datetime format changed on default formatter

# Proposed behavior

# Initialize logger with a custom formatter and datetime_format
logger = Logger.new(formatter: CustomFormatter.new, datetime_format: "%d%b%Y@%H:%M:%S")
logger.info('test')
# => INFO: 19Jul2021@05:02:10 - test
# Could see that datetime format changed on formatter

# Return default formatter for logger
logger.formatter = nil
logger.info('test')
# => I, [2021-07-19T05:03:48.419675 #1216878]  INFO -- : test
# Datatime format not changed on default formatter 

# Initialize logger with a custom formatter and then set datetime_format
logger = Logger.new(formatter: CustomFormatter.new)
logger.datetime_format  = "%d%b%Y@%H:%M:%S"
logger.info('test')
# => INFO: 19Jul2021@05:04:40 - test
# Could see that datetime format changed on formatter

# Return default formatter for logger
logger.formatter = nil
logger.info('test')
# => I, [2021-07-19T05:05:28.419675 #1216878]  INFO -- : test
# Datatime format not changed on default formatter 
```