### PR TITLE
Changes to datetime formatting

### DIFF
--- a/lib/logger/formatter.rb
+++ b/lib/logger/formatter.rb
@@ -3,7 +3,8 @@
 class Logger
   # Default formatter for log messages.
   class Formatter
-    Format = "%s, [%s#%d] %5s -- %s: %s\n"
+    Format = "%s, [%s #%d] %5s -- %s: %s\n"
+    DatetimeFormat = "%Y-%m-%dT%H:%M:%S.%6N"
 
     attr_accessor :datetime_format
 
@@ -19,7 +20,7 @@ class Logger
   private
 
     def format_datetime(time)
-      time.strftime(@datetime_format || "%Y-%m-%dT%H:%M:%S.%6N ")
+      time.strftime(@datetime_format || DatetimeFormat)
     end
 
     def msg2str(msg)

--- a/test/logger/test_formatter.rb
+++ b/test/logger/test_formatter.rb
@@ -1,0 +1,35 @@
+# coding: US-ASCII
+# frozen_string_literal: false
+require_relative 'helper'
+
+class TestFormatter < Test::Unit::TestCase
+  def test_call
+    severity = 'INFO'
+    time = Time.now
+    progname = 'ruby'
+    msg = 'This is a test'
+    formatter = Logger::Formatter.new
+
+    result = formatter.call(severity, time, progname, msg)
+    time_matcher = /\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}/
+    matcher = /#{severity[0..0]}, \[#{time_matcher} #\d+\]  #{severity} -- #{progname}: #{msg}\n/
+
+    assert_match(matcher, result)
+  end
+
+  class CustomFormatter < Logger::Formatter
+    def call(time)
+      format_datetime(time)
+    end
+  end
+
+  def test_format_datetime
+    time = Time.now
+    formatter = CustomFormatter.new
+
+    result = formatter.call(time)
+    matcher = /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$/
+
+    assert_match(matcher, result)
+  end
+end

--- a/test/logger/test_logger.rb
+++ b/test/logger/test_logger.rb
@@ -13,7 +13,7 @@ class TestLogger < Test::Unit::TestCase
   class Log
     attr_reader :label, :datetime, :pid, :severity, :progname, :msg
     def initialize(line)
-      /\A(\w+), \[([^#]*)#(\d+)\]\s+(\w+) -- (\w*): ([\x0-\xff]*)/ =~ line
+      /\A(\w+), \[([^#]*) #(\d+)\]\s+(\w+) -- (\w*): ([\x0-\xff]*)/ =~ line
       @label, @datetime, @pid, @severity, @progname, @msg = $1, $2, $3, $4, $5, $6
     end
   end
@@ -124,7 +124,7 @@ class TestLogger < Test::Unit::TestCase
     dummy = STDERR
     logger = Logger.new(dummy)
     log = log_add(logger, INFO, "foo")
-    assert_match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\s*\d+ $/, log.datetime)
+    assert_match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\s*\d+$/, log.datetime)
     logger.datetime_format = "%d%b%Y@%H:%M:%S"
     log = log_add(logger, INFO, "foo")
     assert_match(/^\d\d\w\w\w\d\d\d\d@\d\d:\d\d:\d\d$/, log.datetime)
@@ -203,7 +203,7 @@ class TestLogger < Test::Unit::TestCase
     # default
     logger = Logger.new(STDERR)
     log = log_add(logger, INFO, "foo")
-    assert_match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\s*\d+ $/, log.datetime)
+    assert_match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\s*\d+$/, log.datetime)
     # config
     logger = Logger.new(STDERR, datetime_format: "%d%b%Y@%H:%M:%S")
     log = log_add(logger, INFO, "foo")


### PR DESCRIPTION
Formatting a datetime should only pertain to itself and valid datetimes do not contain a space. Should there be a desire to show show a space between the datetime and the process pid in the formatted log, this formatting logic should take place there.
Furthermore, the default datetime format is moved to a class variable to allowing this variable to be overwritten by subclasses.