### PR TITLE
gemspec: Drop unused "executables" configuration

### DIFF
--- a/logger.gemspec
+++ b/logger.gemspec
@@ -16,8 +16,6 @@ Gem::Specification.new do |spec|
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
 
   spec.files         = Dir.glob("lib/**/*.rb") + ["logger.gemspec"]
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.3.0"


### PR DESCRIPTION
This gem exposes 0 executables, so we can remove the configuration for that