### PR TITLE
Fix log rotation inter-process lock failed.

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -11,6 +11,7 @@
 # A simple system for logging messages.  See Logger for more documentation.
 
 require 'monitor'
+require 'rbconfig'
 
 require_relative 'logger/version'
 require_relative 'logger/formatter'

--- a/lib/logger/log_device.rb
+++ b/lib/logger/log_device.rb
@@ -135,7 +135,7 @@ class Logger
       end
     end
 
-    if /mswin|mingw|cygwin/ =~ RUBY_PLATFORM
+    if /mswin|mingw|cygwin/ =~ RbConfig::CONFIG['host_os']
       def lock_shift_log
         yield
       end

--- a/test/lib/core_assertions.rb
+++ b/test/lib/core_assertions.rb
@@ -260,7 +260,7 @@ module Test
           line ||= loc.lineno
         end
         capture_stdout = true
-        unless /mswin|mingw/ =~ RUBY_PLATFORM
+        unless /mswin|mingw/ =~ RbConfig::CONFIG['host_os']
           capture_stdout = false
           opt[:out] = Test::Unit::Runner.output if defined?(Test::Unit::Runner)
           res_p, res_c = IO.pipe

--- a/test/logger/test_logdevice.rb
+++ b/test/logger/test_logdevice.rb
@@ -435,6 +435,7 @@ class TestLogDevice < Test::Unit::TestCase
 
         logdev1.write(message)
         assert_file.identical?(log, logdev1.dev)
+        # NOTE: below assertion fails in JRuby 9.3 and TruffleRuby
         assert_file.identical?(log + ".0", logdev2.dev)
 
         logdev2.write(message)
@@ -451,7 +452,7 @@ class TestLogDevice < Test::Unit::TestCase
     end
   ensure
     logdev0.close
-  end unless /mswin|mingw|cygwin/ =~ RUBY_PLATFORM
+  end unless /mswin|mingw|cygwin/ =~ RbConfig::CONFIG['host_os']
 
   def test_shifting_midnight
     Dir.mktmpdir do |tmpdir|


### PR DESCRIPTION
Issue only occurs in JRuby 9.3.0.0 and Windows and the full
console output is:

log rotation inter-process lock failed. D:\log.txt -> D:\log.txt.0: The process cannot access the file because it is being used by another process.
log writing failed. closed stream
log writing failed. closed stream
...