### PR TITLE
Add support for symbols in #shift_age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Accept symbols for shift_age (thanks to [@bazay](https://github.com/bazay))
+
 # 1.4.2
 
 * Document that shift_age of 0 disables log file rotation [#43](https://github.com/ruby/logger/pull/43) (thanks to jeremyevans)

--- a/lib/logger/period.rb
+++ b/lib/logger/period.rb
@@ -8,14 +8,14 @@ class Logger
 
     def next_rotate_time(now, shift_age)
       case shift_age
-      when 'daily'
+      when 'daily', :daily
         t = Time.mktime(now.year, now.month, now.mday) + SiD
-      when 'weekly'
+      when 'weekly', :weekly
         t = Time.mktime(now.year, now.month, now.mday) + SiD * (7 - now.wday)
-      when 'monthly'
+      when 'monthly', :monthly
         t = Time.mktime(now.year, now.month, 1) + SiD * 32
         return Time.mktime(t.year, t.month, 1)
-      when 'now', 'everytime'
+      when 'now', 'everytime', :now, :everytime
         return now
       else
         raise ArgumentError, "invalid :shift_age #{shift_age.inspect}, should be daily, weekly, monthly, or everytime"
@@ -30,13 +30,13 @@ class Logger
 
     def previous_period_end(now, shift_age)
       case shift_age
-      when 'daily'
+      when 'daily', :daily
         t = Time.mktime(now.year, now.month, now.mday) - SiD / 2
-      when 'weekly'
+      when 'weekly', :weekly
         t = Time.mktime(now.year, now.month, now.mday) - (SiD * now.wday + SiD / 2)
-      when 'monthly'
+      when 'monthly', :monthly
         t = Time.mktime(now.year, now.month, 1) - SiD / 2
-      when 'now', 'everytime'
+      when 'now', 'everytime', :now, :everytime
         return now
       else
         raise ArgumentError, "invalid :shift_age #{shift_age.inspect}, should be daily, weekly, monthly, or everytime"

--- a/test/logger/test_logperiod.rb
+++ b/test/logger/test_logperiod.rb
@@ -1,80 +1,67 @@
 # coding: US-ASCII
 # frozen_string_literal: false
-require 'logger'
-require 'time'
+require "logger"
+require "time"
 
 class TestLogPeriod < Test::Unit::TestCase
   def test_next_rotate_time
     time = Time.parse("2019-07-18 13:52:02")
 
-    daily_result = Logger::Period.next_rotate_time(time, 'daily')
-    next_day = Time.parse("2019-07-19 00:00:00")
-    assert_equal(next_day, daily_result)
+    assert_next_rotate_time_words(time, "2019-07-19 00:00:00", ["daily", :daily])
+    assert_next_rotate_time_words(time, "2019-07-21 00:00:00", ["weekly", :weekly])
+    assert_next_rotate_time_words(time, "2019-08-01 00:00:00", ["monthly", :monthly])
 
-    weekly_result = Logger::Period.next_rotate_time(time, 'weekly')
-    next_week = Time.parse("2019-07-21 00:00:00")
-    assert_equal(next_week, weekly_result)
-
-    monthly_result = Logger::Period.next_rotate_time(time, 'monthly')
-    next_month = Time.parse("2019-08-1 00:00:00")
-    assert_equal(next_month, monthly_result)
-
-    assert_raise(ArgumentError) { Logger::Period.next_rotate_time(time, 'invalid') }
+    assert_raise(ArgumentError) { Logger::Period.next_rotate_time(time, "invalid") }
   end
 
   def test_next_rotate_time_extreme_cases
     # First day of Month and Saturday
     time = Time.parse("2018-07-01 00:00:00")
 
-    daily_result = Logger::Period.next_rotate_time(time, 'daily')
-    next_day = Time.parse("2018-07-02 00:00:00")
-    assert_equal(next_day, daily_result)
+    assert_next_rotate_time_words(time, "2018-07-02 00:00:00", ["daily", :daily])
+    assert_next_rotate_time_words(time, "2018-07-08 00:00:00", ["weekly", :weekly])
+    assert_next_rotate_time_words(time, "2018-08-01 00:00:00", ["monthly", :monthly])
 
-    weekly_result = Logger::Period.next_rotate_time(time, 'weekly')
-    next_week = Time.parse("2018-07-08 00:00:00")
-    assert_equal(next_week, weekly_result)
-
-    monthly_result = Logger::Period.next_rotate_time(time, 'monthly')
-    next_month = Time.parse("2018-08-1 00:00:00")
-    assert_equal(next_month, monthly_result)
-
-    assert_raise(ArgumentError) { Logger::Period.next_rotate_time(time, 'invalid') }
+    assert_raise(ArgumentError) { Logger::Period.next_rotate_time(time, "invalid") }
   end
 
   def test_previous_period_end
     time = Time.parse("2019-07-18 13:52:02")
 
-    daily_result = Logger::Period.previous_period_end(time, 'daily')
-    day_ago = Time.parse("2019-07-17 23:59:59")
-    assert_equal(day_ago, daily_result)
+    assert_previous_period_end_words(time, "2019-07-17 23:59:59", ["daily", :daily])
+    assert_previous_period_end_words(time, "2019-07-13 23:59:59", ["weekly", :weekly])
+    assert_previous_period_end_words(time, "2019-06-30 23:59:59", ["monthly", :monthly])
 
-    weekly_result = Logger::Period.previous_period_end(time, 'weekly')
-    week_ago = Time.parse("2019-07-13 23:59:59")
-    assert_equal(week_ago, weekly_result)
-
-    monthly_result = Logger::Period.previous_period_end(time, 'monthly')
-    month_ago = Time.parse("2019-06-30 23:59:59")
-    assert_equal(month_ago, monthly_result)
-
-    assert_raise(ArgumentError) { Logger::Period.next_rotate_time(time, 'invalid') }
+    assert_raise(ArgumentError) { Logger::Period.previous_period_end(time, "invalid") }
   end
 
   def test_previous_period_end_extreme_cases
     # First day of Month and Saturday
     time = Time.parse("2018-07-01 00:00:00")
+    previous_date = "2018-06-30 23:59:59"
 
-    daily_result = Logger::Period.previous_period_end(time, 'daily')
-    day_ago = Time.parse("2018-06-30 23:59:59")
-    assert_equal(day_ago, daily_result)
+    assert_previous_period_end_words(time, previous_date, ["daily", :daily])
+    assert_previous_period_end_words(time, previous_date, ["weekly", :weekly])
+    assert_previous_period_end_words(time, previous_date, ["monthly", :monthly])
 
-    weekly_result = Logger::Period.previous_period_end(time, 'weekly')
-    week_ago = Time.parse("2018-06-30 23:59:59")
-    assert_equal(week_ago, weekly_result)
+    assert_raise(ArgumentError) { Logger::Period.previous_period_end(time, "invalid") }
+  end
 
-    monthly_result = Logger::Period.previous_period_end(time, 'monthly')
-    month_ago = Time.parse("2018-06-30 23:59:59")
-    assert_equal(month_ago, monthly_result)
+  private
 
-    assert_raise(ArgumentError) { Logger::Period.next_rotate_time(time, 'invalid') }
+  def assert_next_rotate_time_words(time, next_date, words)
+    assert_time_words(:next_rotate_time, time, next_date, words)
+  end
+
+  def assert_previous_period_end_words(time, previous_date, words)
+    assert_time_words(:previous_period_end, time, previous_date, words)
+  end
+
+  def assert_time_words(method, time, date, words)
+    words.each do |word|
+      daily_result = Logger::Period.public_send(method, time, word)
+      expected_result = Time.parse(date)
+      assert_equal(expected_result, daily_result)
+    end
   end
 end


### PR DESCRIPTION
Resolves issue: https://github.com/ruby/logger/issues/46