### PR TITLE
Perf improvement on Logger::Formatter#call

### DIFF
--- a/lib/logger/formatter.rb
+++ b/lib/logger/formatter.rb
@@ -13,7 +13,7 @@ class Logger
     end
 
     def call(severity, time, progname, msg)
-      Format % [severity[0..0], format_datetime(time), Process.pid, severity, progname,
+      Format % [severity[0, 1], format_datetime(time), Process.pid, severity, progname,
         msg2str(msg)]
     end
 


### PR DESCRIPTION
Here's a tiny performance improvement that suppresses an extra Array object creation on the Logger::Formatter per each `call`.

Just in case anyone needs a benchmark, here's a micro benchmark/ips result on `String#[0..0]` vs `String#[0, 1]`.

```ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  string = 'debug'

  x.report('[0..0]') { string[0..0] }
  x.report('[0, 1]') { string[0, 1] }

  x.compare!
end
```

```
Warming up --------------------------------------
              [0..0]     1.013M i/100ms
              [0, 1]     1.097M i/100ms
Calculating -------------------------------------
              [0..0]     10.145M (± 0.7%) i/s -     51.666M in   5.093090s
              [0, 1]     10.946M (± 0.7%) i/s -     54.835M in   5.009652s

Comparison:
              [0, 1]: 10946494.4 i/s
              [0..0]: 10144924.5 i/s - 1.08x  (± 0.00) slower
```