### PR TITLE
Another performance improvement on the Formatter by using Kernel#sprintf over String#%

### DIFF
--- a/lib/logger/formatter.rb
+++ b/lib/logger/formatter.rb
@@ -3,7 +3,7 @@
 class Logger
   # Default formatter for log messages.
   class Formatter
-    Format = "%s, [%s #%d] %5s -- %s: %s\n"
+    Format = "%.1s, [%s #%d] %5s -- %s: %s\n"
     DatetimeFormat = "%Y-%m-%dT%H:%M:%S.%6N"
 
     attr_accessor :datetime_format
@@ -13,7 +13,7 @@ class Logger
     end
 
     def call(severity, time, progname, msg)
-      sprintf(Format, severity[0, 1], format_datetime(time), Process.pid, severity, progname, msg2str(msg))
+      sprintf(Format, severity, format_datetime(time), Process.pid, severity, progname, msg2str(msg))
     end
 
   private

--- a/lib/logger/formatter.rb
+++ b/lib/logger/formatter.rb
@@ -13,8 +13,7 @@ class Logger
     end
 
     def call(severity, time, progname, msg)
-      Format % [severity[0, 1], format_datetime(time), Process.pid, severity, progname,
-        msg2str(msg)]
+      sprintf(Format, severity[0, 1], format_datetime(time), Process.pid, severity, progname, msg2str(msg))
     end
 
   private


### PR DESCRIPTION
`String#%` takes the arguments as an Array object, which requires us to create an extra object (like we're doing [here](https://github.com/ruby/logger/blob/cafbc353ab4cf0bcf871830f21cce8b5288071b6/lib/logger/formatter.rb#L16-L17)).

Also, while both `String#%` and `Kernel#sprintf` internally falls back `rb_str_format` in the current CRuby implementation, the former seems to be performing a little bit of argument checking, which possibly causes a very subtle performance difference (?).

Anyway, here's a benchmark of `String#%` vs `Kernel#sprintf`.

```ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  Format = "%s, [%s #%d] %5s -- %s: %s\n"
  DatetimeFormat = "%Y-%m-%dT%H:%M:%S.%6N"
  time = Time.now.strftime(DatetimeFormat)
  pid = Process.pid

  x.report('String#%') { Format % ['D', time, pid, 'DEBUG', 'hello', 'world'] }
  x.report('sprintf') { sprintf(Format, 'D', time, pid, 'DEBUG', 'hello', 'world') }

  x.compare!
end
```

```
Warming up --------------------------------------
            String#%   205.492k i/100ms
             sprintf   219.627k i/100ms
Calculating -------------------------------------
            String#%      2.057M (± 0.9%) i/s -     10.480M in   5.094731s
             sprintf      2.193M (± 0.8%) i/s -     10.981M in   5.006767s

Comparison:
             sprintf:  2193434.0 i/s
            String#%:  2057237.4 i/s - 1.07x  (± 0.00) slower
```

P.S. I have no strong preference on whether to use `Kernel#sprintf` or `Kernel#format`.  I'm happy to rewrite the patch to call `format(...)` (or `Kernel.sprintf(...)` or `Kernel.format(...)`) if the maintainer has any preference.