### PR TITLE
Add thread-local log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# HEAD
+
+* Add thread-local log levels using `Logger#with_level` [#84](https://github.com/ruby/logger/issue/84)
+
 # 1.4.2
 
 * Document that shift_age of 0 disables log file rotation [#43](https://github.com/ruby/logger/pull/43) (thanks to jeremyevans)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HEAD
 
-* Add thread-local log levels using `Logger#with_level` [#84](https://github.com/ruby/logger/issue/84)
+* Support fiber-local log levels using `Logger#with_level` [#84](https://github.com/ruby/logger/issue/84)
 
 # 1.4.2
 

--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -10,6 +10,7 @@
 #
 # A simple system for logging messages.  See Logger for more documentation.
 
+require 'fiber'
 require 'monitor'
 require 'rbconfig'
 

--- a/lib/logger/severity.rb
+++ b/lib/logger/severity.rb
@@ -30,8 +30,8 @@ class Logger
       if severity.is_a?(Integer)
         severity
       else
-        k = severity.to_s.downcase
-        LEVELS[k] || raise(ArgumentError, "invalid log level: #{severity}")
+        key = severity.to_s.downcase
+        LEVELS[key] || raise(ArgumentError, "invalid log level: #{severity}")
       end
     end
   end

--- a/lib/logger/severity.rb
+++ b/lib/logger/severity.rb
@@ -16,26 +16,22 @@ class Logger
     # An unknown message that should always be logged.
     UNKNOWN = 5
 
+    LEVELS = {
+      "debug" => DEBUG,
+      "info" => INFO,
+      "warn" => WARN,
+      "error" => ERROR,
+      "fatal" => FATAL,
+      "unknown" => UNKNOWN,
+    }
+    private_constant :LEVELS
+
     def self.coerce(severity)
       if severity.is_a?(Integer)
         severity
       else
-        case severity.to_s.downcase
-        when 'debug'
-          DEBUG
-        when 'info'
-          INFO
-        when 'warn'
-          WARN
-        when 'error'
-          ERROR
-        when 'fatal'
-          FATAL
-        when 'unknown'
-          UNKNOWN
-        else
-          raise ArgumentError, "invalid log level: #{severity}"
-        end
+        k = severity.to_s.downcase
+        LEVELS[k] || raise(ArgumentError, "invalid log level: #{severity}")
       end
     end
   end

--- a/lib/logger/severity.rb
+++ b/lib/logger/severity.rb
@@ -15,5 +15,28 @@ class Logger
     FATAL = 4
     # An unknown message that should always be logged.
     UNKNOWN = 5
+
+    def self.coerce(severity)
+      if severity.is_a?(Integer)
+        severity
+      else
+        case severity.to_s.downcase
+        when 'debug'
+          DEBUG
+        when 'info'
+          INFO
+        when 'warn'
+          WARN
+        when 'error'
+          ERROR
+        when 'fatal'
+          FATAL
+        when 'unknown'
+          UNKNOWN
+        else
+          raise ArgumentError, "invalid log level: #{severity}"
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds Logger#with_level which provides a thread-local log level so Threads can temporarily enable logging for a given block.

```ruby
log = Logger.new
log.level = :info

Thread.new do
  log.with_level(:debug) do
    log.debug("Will log")
  end
end.join

log.debug("Won't log")
```

Fixes #84 