### PR TITLE
Enable log file rotation on Windows

### DIFF
--- a/test/logger/test_logdevice.rb
+++ b/test/logger/test_logdevice.rb
@@ -452,7 +452,7 @@ class TestLogDevice < Test::Unit::TestCase
     end
   ensure
     logdev0.close
-  end unless /mswin|mingw|cygwin/ =~ RbConfig::CONFIG['host_os']
+  end
 
   def test_shifting_midnight
     Dir.mktmpdir do |tmpdir|


### PR DESCRIPTION
Since ruby 2.3, a file opened with `File::SHARE_DELETE` and `File::BINARY` can be renamed or removed.