### PR TITLE
Enable subclasses to configure level isolation

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -381,7 +381,7 @@ class Logger
 
   # Logging severity threshold (e.g. <tt>Logger::INFO</tt>).
   def level
-    level_override[Fiber.current] || @level
+    level_override[level_key] || @level
   end
 
   # Sets the log level; returns +severity+.
@@ -406,14 +406,14 @@ class Logger
   #     logger.debug { "Hello" }
   #   end
   def with_level(severity)
-    prev, level_override[Fiber.current] = level, Severity.coerce(severity)
+    prev, level_override[level_key] = level, Severity.coerce(severity)
     begin
       yield
     ensure
       if prev
-        level_override[Fiber.current] = prev
+        level_override[level_key] = prev
       else
-        level_override.delete(Fiber.current)
+        level_override.delete(level_key)
       end
     end
   end
@@ -749,6 +749,10 @@ private
   # Guarantee the existence of this ivar even when subclasses don't call the superclass constructor.
   def level_override
     @level_override ||= {}
+  end
+
+  def level_key
+    Fiber.current
   end
 
   def format_message(severity, datetime, progname, msg)

--- a/test/logger/test_severity.rb
+++ b/test/logger/test_severity.rb
@@ -26,7 +26,7 @@ class TestLoggerSeverity < Test::Unit::TestCase
     end
   end
 
-  def test_thread_local_level
+  def test_fiber_local_level
     logger = Logger.new(nil)
     logger.level = INFO # default level
     other = Logger.new(nil)
@@ -40,14 +40,50 @@ class TestLoggerSeverity < Test::Unit::TestCase
       logger.with_level(DEBUG) do # verify reentrancy
         assert_equal(logger.level, DEBUG)
 
-        Thread.new do
+        Fiber.new do
           assert_equal(logger.level, INFO)
           logger.with_level(:WARN) do
             assert_equal(other.level, ERROR)
             assert_equal(logger.level, WARN)
           end
           assert_equal(logger.level, INFO)
-        end.join
+        end.resume
+
+        assert_equal(logger.level, DEBUG)
+      end
+      assert_equal(logger.level, WARN)
+    end
+    assert_equal(logger.level, INFO)
+  end
+
+  def test_thread_local_level
+    subclass = Class.new(Logger) do
+      def level_key
+        Thread.current
+      end
+    end
+
+    logger = subclass.new(nil)
+    logger.level = INFO # default level
+    other = subclass.new(nil)
+    other.level = ERROR # default level
+
+    assert_equal(other.level, ERROR)
+    logger.with_level(:WARN) do
+      assert_equal(other.level, ERROR)
+      assert_equal(logger.level, WARN)
+
+      logger.with_level(DEBUG) do # verify reentrancy
+        assert_equal(logger.level, DEBUG)
+
+        Fiber.new do
+          assert_equal(logger.level, DEBUG)
+          logger.with_level(:WARN) do
+            assert_equal(other.level, ERROR)
+            assert_equal(logger.level, WARN)
+          end
+          assert_equal(logger.level, DEBUG)
+        end.resume
 
         assert_equal(logger.level, DEBUG)
       end


### PR DESCRIPTION
`Logger#with_level` was recently added to enable configuring a `Logger`'s level for the duration of a block. However, the configured level is always tied to the currently running `Fiber`, which is not always ideal in applications that mix `Thread`s and `Fiber`s.

For example, Active Support has provided a similar feature (`ActiveSupport::Logger#log_at`) which, depending on configuration, can be isolated to either `Thread`s or `Fiber`s.

This commit enables subclasses of `Logger` to customize the level isolation. Ideally, it will enable replacing most of Active Support's `#log_at`, since both methods end up serving the same purpose.