### PR TITLE
include license texts in gem

### DIFF
--- a/logger.gemspec
+++ b/logger.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ruby/logger"
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
 
-  spec.files         = Dir.glob("lib/**/*.rb") + ["logger.gemspec"]
+  spec.files         = Dir.glob("lib/**/*.rb") + ["logger.gemspec", "BSDL", "COPYING"]
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.5.0"


### PR DESCRIPTION
So that supply chain tools that look for licenses in the gem can find them, for example https://github.com/github/licensed/pull/765/commits/ff8a5187176d3515cd5afd42ed77db5f043abfd1 (the commit comment there is inaccurate, substitute `logger.gemspec` for `Rakefile`) and so that people distributing the gem automatically comply with the licenses which require copies of the licenses.