### PR TITLE
update license files in rdoc task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ require "rdoc/task"
 RDoc::Task.new do |doc|
   doc.main   = "README.md"
   doc.title  = "Logger -- Ruby Standard Logger"
-  doc.rdoc_files = FileList.new %w[README.md lib LICENSE.txt]
+  doc.rdoc_files = FileList.new %w[README.md lib BSDL COPYING]
   doc.rdoc_dir = "html"
 end
 


### PR DESCRIPTION
I intended to fix #104 but this still results in a broken link.

Because https://ruby.github.io/logger/ hadn't been rebuilt in awhile https://ruby.github.io/logger/LICENSE_txt.html exists but the link on https://ruby.github.io/logger/index.html points to https://ruby.github.io/logger/LICENSE.txt which does not.

With the change in this PR, the updated license files get added, and the link changed to /BSDL which does not.

There must be some RDoc convention or hint so that the right URL gets emitted that I do not know.

Still, this PR at least allows the rdoc task to succeed (it failed before as LICENSE.txt no longer exists).