### PR TITLE
Use `__FILE__` for wasm

### DIFF
--- a/lib/logger/log_device.rb
+++ b/lib/logger/log_device.rb
@@ -223,7 +223,7 @@ class Logger
   end
 end
 
-File.open(IO::NULL) do |f|
+File.open(__FILE__) do |f|
   File.new(f.fileno, autoclose: false, path: "").path
 rescue IOError
   module PathAttr               # :nodoc:


### PR DESCRIPTION
`/dev/null` is not available on wasm.