### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/logger

### DIFF
--- a/logger.gemspec
+++ b/logger.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.5.0"
+
+  spec.metadata["changelog_uri"] = spec.homepage + "/releases"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/logger which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/#metadata