### PR TITLE
Add workaround for TruffleRuby and do not use File::SHARE_DELETE

### DIFF
--- a/lib/logger/log_device.rb
+++ b/lib/logger/log_device.rb
@@ -70,7 +70,12 @@ class Logger
     # :stopdoc:
 
     MODE = File::WRONLY | File::APPEND
-    MODE_TO_OPEN = MODE | File::SHARE_DELETE | File::BINARY
+    # temporary workaround for TruffleRuby
+    if File.const_defined? :SHARE_DELETE
+      MODE_TO_OPEN = MODE | File::SHARE_DELETE | File::BINARY
+    else
+      MODE_TO_OPEN = MODE | File::BINARY
+    end
     MODE_TO_CREATE = MODE_TO_OPEN | File::CREAT | File::EXCL
 
     def set_dev(log)


### PR DESCRIPTION
Fix logger on TruffleRuby.

TruffleRuby is missing a `File::SHARE_DELETE` constant that is in logger since #102. It was fixed in the TruffleRuby trunk and will be released in the next version.

This proposed temporary workaround in logger is needed to make it work on the current TruffleRuby release.

TruffleRuby issue https://github.com/oracle/truffleruby/issues/3745