### PR TITLE
Accept the object that has #to_path in Logger::LogDevice.new

### DIFF
--- a/lib/logger/log_device.rb
+++ b/lib/logger/log_device.rb
@@ -99,6 +99,7 @@ class Logger
     else
       def fixup_mode(dev, filename)
         return dev if @binmode
+        filename = filename.respond_to?(:to_path) ? filename.to_path : filename
         dev.autoclose = false
         old_dev = dev
         dev = File.new(dev.fileno, mode: MODE, path: filename)

--- a/test/logger/test_logdevice.rb
+++ b/test/logger/test_logdevice.rb
@@ -3,6 +3,7 @@
 require 'logger'
 require 'tempfile'
 require 'tmpdir'
+require 'pathname'
 
 class TestLogDevice < Test::Unit::TestCase
   class LogExcnRaiser
@@ -77,6 +78,20 @@ class TestLogDevice < Test::Unit::TestCase
     ensure
       logdev.close
       File.unlink(tempfile)
+      tempfile.close(true)
+    end
+    # logfile object with Pathname object
+    tempfile = Tempfile.new("logger")
+    pathname = Pathname.new(tempfile.path)
+    logdev = d(pathname)
+    begin
+      logdev.write('world')
+      logfile = File.read(pathname)
+      assert_equal(1, logfile.split(/\n/).size)
+      assert_match(/^world$/, logfile)
+      assert_equal(pathname, logdev.filename)
+    ensure
+      logdev.close
       tempfile.close(true)
     end
   end


### PR DESCRIPTION
Because the `path` keyword in File.new will only accept objects that have `to_str`.

The issue I reported in https://github.com/ruby/logger/issues/107#issuecomment-2558300295 will be fixed.
