### PR TITLE
[Feature #21133] Add `skip_header` option

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -577,11 +577,14 @@ class Logger
   # - +reraise_write_errors+: An array of exception classes, which will
   #   be reraised if there is an error when writing to the log device.
   #   The default is to swallow all exceptions raised.
+  # - +skip_header+: If +true+, prevents the logger from writing a header
+  #   when creating a new log file. The default is +false+, meaning
+  #   the header will be written as usual.
   #
   def initialize(logdev, shift_age = 0, shift_size = 1048576, level: DEBUG,
                  progname: nil, formatter: nil, datetime_format: nil,
                  binmode: false, shift_period_suffix: '%Y%m%d',
-                 reraise_write_errors: [])
+                 reraise_write_errors: [], skip_header: false)
     self.level = level
     self.progname = progname
     @default_formatter = Formatter.new
@@ -594,7 +597,8 @@ class Logger
         shift_size: shift_size,
         shift_period_suffix: shift_period_suffix,
         binmode: binmode,
-        reraise_write_errors: reraise_write_errors)
+        reraise_write_errors: reraise_write_errors,
+        skip_header: skip_header)
     end
   end
 

--- a/lib/logger/log_device.rb
+++ b/lib/logger/log_device.rb
@@ -11,10 +11,14 @@ class Logger
     attr_reader :filename
     include MonitorMixin
 
-    def initialize(log = nil, shift_age: nil, shift_size: nil, shift_period_suffix: nil, binmode: false, reraise_write_errors: [])
+    def initialize(
+      log = nil, shift_age: nil, shift_size: nil, shift_period_suffix: nil,
+      binmode: false, reraise_write_errors: [], skip_header: false
+    )
       @dev = @filename = @shift_age = @shift_size = @shift_period_suffix = nil
       @binmode = binmode
       @reraise_write_errors = reraise_write_errors
+      @skip_header = skip_header
       mon_initialize
       set_dev(log)
       set_file(shift_age, shift_size, shift_period_suffix) if @filename
@@ -132,7 +136,7 @@ class Logger
         logdev = fixup_mode(logdev)
         logdev.sync = true
         logdev.binmode if @binmode
-        add_log_header(logdev)
+        add_log_header(logdev) unless @skip_header
         logdev.flock(File::LOCK_UN)
         logdev
       rescue Errno::EEXIST

--- a/test/logger/test_logdevice.rb
+++ b/test/logger/test_logdevice.rb
@@ -502,6 +502,12 @@ class TestLogDevice < Test::Unit::TestCase
     end
   end
 
+  def test_open_without_header
+    d(@filename, skip_header: true)
+
+    assert_equal("", File.read(@filename))
+  end
+
   def test_open_logfile_in_multiprocess
     tmpfile = Tempfile.new([File.basename(__FILE__, '.*'), '_1.log'])
     logfile = tmpfile.path


### PR DESCRIPTION
Creating a logger automatically writes a hardcoded header comment ("# Logfile created on ...").
While this helps verify that logdev is writable as early as possible (rather than on the first log entry), it also serves as a useful indicator of which program created the logfile.

However, this header can introduce unnecessary
complexity -- especially when working with third-party tools that need to ignore these lines.

This commit introduces a `skip_header` boolean
option (default is `false`), allowing API consumers to disable the header if needed.

issue: https://bugs.ruby-lang.org/issues/21133