### PR TITLE
Subclasses `initialize` must call super

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -749,6 +749,15 @@ private
 
   # Guarantee the existence of this ivar even when subclasses don't call the superclass constructor.
   def level_override
+    unless defined?(@level_override)
+      bad = self.class.instance_method(:initialize)
+      file, line = bad.source_location
+      Kernel.warn <<~";;;", uplevel: 2
+        Logger not initialized properly
+        #{file}:#{line}: info: #{bad.owner}\##{bad.name}: \
+        does not call super probably
+      ;;;
+    end
     @level_override ||= {}
   end
 

--- a/test/logger/test_logger.rb
+++ b/test/logger/test_logger.rb
@@ -399,4 +399,19 @@ class TestLogger < Test::Unit::TestCase
     l = Logger.new(File::NULL)
     assert_nil(l.instance_variable_get(:@logdev))
   end
+
+  def test_subclass_initialize
+    bad_logger = Class.new(Logger) {def initialize(*); end}.new(IO::NULL)
+    line = __LINE__ - 1
+    file = Regexp.quote(__FILE__)
+    assert_warning(/not initialized properly.*\n#{file}:#{line}:/) do
+      bad_logger.level
+    end
+
+    good_logger = Class.new(Logger) {def initialize(*); super; end}.new(IO::NULL)
+    file = Regexp.quote(__FILE__)
+    assert_warning('') do
+      good_logger.level
+    end
+  end
 end


### PR DESCRIPTION
Warn wrong code, https://github.com/ruby/logger/pull/100:
> Some Ruby apps subclass Logger without running the superclass constructor, which means that `@level_override` isn't initialized properly.