### PR TITLE
Clear level overrides in `#dup` and `#clone`

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -380,7 +380,7 @@ class Logger
   include Severity
 
   # Must respond to .new and return a Hash-like object.
-  # The returned object must respond to #[], #[]=, #delete.
+  # The returned object must respond to #[], #[]=, #delete, #dup, and #clear.
   #
   # ObjectSpace::WeakKeyMap when supported.
   OverrideMap =
@@ -798,6 +798,11 @@ private
       ;;;
     end
     @level_override ||= OverrideMap.new
+  end
+
+  def initialize_copy(other)
+    super
+    @level_override = @level_override&.clone&.clear
   end
 
   def level_key

--- a/test/logger/test_severity.rb
+++ b/test/logger/test_severity.rb
@@ -31,20 +31,31 @@ class TestLoggerSeverity < Test::Unit::TestCase
     logger.level = INFO # default level
     other = Logger.new(nil)
     other.level = ERROR # default level
+    clone = logger.clone # should not be chaged
 
     assert_equal(other.level, ERROR)
     logger.with_level(:WARN) do
       assert_equal(other.level, ERROR)
       assert_equal(logger.level, WARN)
+      assert_equal(clone.level, INFO)
+      assert_equal(logger.dup.level, INFO)
+      assert_equal(logger.clone.level, INFO)
+      logger.clone.with_level(:FATAL) do
+        assert_equal(logger.level, WARN)
+      end
 
       logger.with_level(DEBUG) do # verify reentrancy
         assert_equal(logger.level, DEBUG)
+        assert_equal(clone.level, INFO)
 
         Fiber.new do
           assert_equal(logger.level, INFO)
           logger.with_level(:WARN) do
             assert_equal(other.level, ERROR)
             assert_equal(logger.level, WARN)
+            assert_equal(clone.level, INFO)
+            assert_equal(logger.dup.level, INFO)
+            assert_equal(logger.clone.level, INFO)
           end
           assert_equal(logger.level, INFO)
         end.resume
@@ -67,20 +78,31 @@ class TestLoggerSeverity < Test::Unit::TestCase
     logger.level = INFO # default level
     other = subclass.new(nil)
     other.level = ERROR # default level
+    clone = logger.clone # should not be chaged
 
     assert_equal(other.level, ERROR)
     logger.with_level(:WARN) do
       assert_equal(other.level, ERROR)
       assert_equal(logger.level, WARN)
+      assert_equal(clone.level, INFO)
+      assert_equal(logger.dup.level, INFO)
+      assert_equal(logger.clone.level, INFO)
+      logger.clone.with_level(:FATAL) do
+        assert_equal(logger.level, WARN)
+      end
 
       logger.with_level(DEBUG) do # verify reentrancy
         assert_equal(logger.level, DEBUG)
+        assert_equal(clone.level, INFO)
 
         Fiber.new do
           assert_equal(logger.level, DEBUG)
           logger.with_level(:WARN) do
             assert_equal(other.level, ERROR)
             assert_equal(logger.level, WARN)
+            assert_equal(clone.level, INFO)
+            assert_equal(logger.dup.level, INFO)
+            assert_equal(logger.clone.level, INFO)
           end
           assert_equal(logger.level, DEBUG)
         end.resume


### PR DESCRIPTION
Cloning loggers can be used, for example, to create different loggers for different classes/components/subsystems that share the same log_dev and other configuration (possibly a subclass of Logger), but with different verbosity levels, formatters, etc.

But, that can break if they share `@level_override`.  Rather than use OverrideMap.new, the existing `@level_override` is cloned and cleared, to preserve `@level_override`'s class.

----

This PR is based on #136 to avoid merge conflicts.  But it can be updated to be independent of that other PR, if so desired.