### PR TITLE
Fix `datetime_format` to apply to custom formatters

### DIFF
--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -430,13 +430,17 @@ class Logger
   # - +nil+: the logger uses <tt>'%Y-%m-%dT%H:%M:%S.%6N'</tt>.
   #
   def datetime_format=(datetime_format)
-    @default_formatter.datetime_format = datetime_format
+    formatter = @formatter || @default_formatter
+    if formatter.respond_to?(:datetime_format=)
+      formatter.datetime_format = datetime_format
+    end
   end
 
   # Returns the date-time format; see #datetime_format=.
   #
   def datetime_format
-    @default_formatter.datetime_format
+    formatter = @formatter || @default_formatter
+    formatter.datetime_format if formatter.respond_to?(:datetime_format)
   end
 
   # Sets or retrieves the logger entry formatter proc.
@@ -603,8 +607,8 @@ class Logger
     self.level = level
     self.progname = progname
     @default_formatter = Formatter.new
-    self.datetime_format = datetime_format
     self.formatter = formatter
+    self.datetime_format = datetime_format
     @logdev = nil
     @level_override = {}
     return unless logdev

--- a/test/logger/test_logger.rb
+++ b/test/logger/test_logger.rb
@@ -229,6 +229,27 @@ class TestLogger < Test::Unit::TestCase
     assert_match(/^\d\d\w\w\w\d\d\d\d@\d\d:\d\d:\d\d$/, log.datetime)
   end
 
+  def test_datetime_format_with_custom_formatter
+    dummy = STDERR
+    custom_formatter = Logger::Formatter.new
+    logger = Logger.new(dummy, formatter: custom_formatter)
+    # datetime_format= applies to the custom formatter
+    logger.datetime_format = "%d%b%Y@%H:%M:%S"
+    assert_equal("%d%b%Y@%H:%M:%S", logger.datetime_format)
+    assert_equal("%d%b%Y@%H:%M:%S", custom_formatter.datetime_format)
+    log = log_add(logger, INFO, "foo")
+    assert_match(/^\d\d\w\w\w\d\d\d\d@\d\d:\d\d:\d\d$/, log.datetime)
+  end
+
+  def test_initialize_with_formatter_and_datetime_format
+    custom_formatter = Logger::Formatter.new
+    logger = Logger.new(STDERR, formatter: custom_formatter, datetime_format: "%d%b%Y@%H:%M:%S")
+    assert_equal("%d%b%Y@%H:%M:%S", logger.datetime_format)
+    assert_equal("%d%b%Y@%H:%M:%S", custom_formatter.datetime_format)
+    log = log_add(logger, INFO, "foo")
+    assert_match(/^\d\d\w\w\w\d\d\d\d@\d\d:\d\d:\d\d$/, log.datetime)
+  end
+
   def test_reopen
     logger = Logger.new(STDERR)
     logger.reopen(STDOUT)


### PR DESCRIPTION
## Summary

- Fix `datetime_format=` and `datetime_format` to delegate to the active
  formatter (`@formatter` or `@default_formatter`) instead of always using
  `@default_formatter`
- Use `respond_to?` to gracefully handle formatters (e.g. Proc) that do not
  support `datetime_format`
- Reorder `initialize` so `datetime_format` is set after the custom formatter
  is assigned

Fixes #154 

## Test plan

- Added `test_datetime_format_with_custom_formatter`: verifies that
  `datetime_format=` applies to a custom formatter set after initialization
- Added `test_initialize_with_formatter_and_datetime_format`: verifies that
  passing both `formatter:` and `datetime_format:` to `Logger.new` applies
  the format to the custom formatter
- Existing `test_datetime_format`, `test_initialize_with_formatter`, and
  `test_initialize_with_datetime_format` continue to pass